### PR TITLE
Fix/user mask overwrite

### DIFF
--- a/iris/segmentation/static/javascripts/segmentation.js
+++ b/iris/segmentation/static/javascripts/segmentation.js
@@ -2795,9 +2795,6 @@ async function legacyPredictMask(){
     for (var i = 0; i < results.data.length; i++) {
         if (!currentUserMaskData[i]){
             newMaskData[i] = results.data[i];
-            // CRITICAL: Also mark this pixel as "drawn" in userMask
-            // so it gets saved and rendered
-            newUserMaskData[i] = 1;
             aiPixelsApplied++;
         }
     }

--- a/iris/segmentation/static/javascripts/segmentation.js
+++ b/iris/segmentation/static/javascripts/segmentation.js
@@ -2788,8 +2788,7 @@ async function legacyPredictMask(){
     }
     
     const newMaskData = new Uint8Array(currentMaskData);
-    const newUserMaskData = new Uint8Array(currentUserMaskData);
-    
+
     // Only update the mask where the user did not draw to
     let aiPixelsApplied = 0;
     for (var i = 0; i < results.data.length; i++) {
@@ -2798,24 +2797,11 @@ async function legacyPredictMask(){
             aiPixelsApplied++;
         }
     }
-    
+
     console.log(`[IRIS] AI Prediction: Applied ${aiPixelsApplied} AI-predicted pixels`);
-    
-    // Update store with prediction results (ONLY SOURCE)
+
+    // Update store with prediction results
     window.setMaskDataInStore(newMaskData, maskShape[0], maskShape[1]);
-    window.setUserMaskDataInStore(newUserMaskData);
-    console.log('[IRIS Migration] ✅ Applied prediction results using React store');
-    
-    // Verify the store was updated
-    const verifyMaskData = window.getMaskDataFromStore();
-    const verifyUserMaskData = window.getUserMaskDataFromStore();
-    let verifyAiPixels = 0;
-    for (var i = 0; i < verifyMaskData.length; i++) {
-        if (verifyUserMaskData[i] === 1 && verifyMaskData[i] !== 0){
-            verifyAiPixels++;
-        }
-    }
-    console.log(`[IRIS] AI Prediction: Verified ${verifyAiPixels} total pixels in store after update`);
     
     reload_hidden_mask();
     render_mask();


### PR DESCRIPTION
Hotfix for issue I noticed during some testing. After annotating pixels, then training, the AI predictions would be incorrectly included in the user mask, and not only the final mask. 

This PR fixes the problem by stopping the writing of those pixels to the newUserMaskData. In fact, newUserMaskData is not necessary at all in the legacyPredictMask() function, as predictions will never influence the user mask.

To reproduce error in code prior to hotfix:

(i) reset mask (remove all user and ai pixels)
(ii) draw pixels of 2 classes (observe the user mask correctly visualises the brushstrokes)
(iii)train AI model
(iv) observe user mask again, which will now be filled with all the AI's predictions, filling in the whole image around the user's annotations

